### PR TITLE
Fix NSURLErrorDomain codes key in example plist

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The following example RMErrors.plist will setup RMErrors to:
 			</dict>
 			<key>codes</key>
 			<dict>
-				<key>-1003..-1009</key>
+				<key>-1009..-1003</key>
 				<dict>
 					<key>transient</key>
 					<true/>


### PR DESCRIPTION
Hi,
Thanks for making this great library! I ran into a problem using the example plist and wanted to submit a fix for it. In the README, the range for the codes key should be min..max and are flipped in the sample
since the codes are negative numbers. Using the current example plist, an error with code -1004 won't get caught.      
